### PR TITLE
ADD: JWT-refresh token 기능 추가

### DIFF
--- a/db/migrations/20230302063112_add_refresh_token.sql
+++ b/db/migrations/20230302063112_add_refresh_token.sql
@@ -1,0 +1,6 @@
+-- migrate:up
+ALTER TABLE users ADD refresh_token text NOT NULL;
+
+
+-- migrate:down
+

--- a/src/controllers/likeController.js
+++ b/src/controllers/likeController.js
@@ -3,7 +3,7 @@ const { Errors } = require("../util/errors");
 const { catchAsync } = require("../util/errors");
 
 const createLike = catchAsync(async (req, res) => {
-  const userId = req.user.id;
+  const userId = req.id;
   const { productId } = req.body;
 
   if (!productId) {
@@ -15,7 +15,7 @@ const createLike = catchAsync(async (req, res) => {
 });
 
 const getLikeList = async (req, res) => {
-  const userId = req.user.id;
+  const userId = req.id;
 
   const [products, name] = await likeService.getLikeList(userId);
   res.status(200).json([products, name]);

--- a/src/controllers/userController.js
+++ b/src/controllers/userController.js
@@ -17,8 +17,8 @@ const signin = async (req, res) => {
   const { email, password } = req.body;
 
   try {
-    const accessToken = await userService.signin(email, password);
-    res.status(200).json({ accessToken });
+    const { access_token, refresh_token } = await userService.signin(email, password);
+    res.status(200).json({ access_token, refresh_token });
   } catch (error) {
     res.status(error.statusCode || 400).json({ message: error.message });
   }

--- a/src/models/userDao.js
+++ b/src/models/userDao.js
@@ -10,10 +10,28 @@ const createUser = async (name, phone, email, password) => {
         password) 
       VALUES (?, ?, ?, ?)
           `,
-      [ name, phone, email, password ]
+      [name, phone, email, password]
     );
   } catch (err) {
+    console.log(err);
     throw new Error("INVALID DATA INPUT");
+  }
+};
+
+const createRefreshToken = async (refresh_token, userId) => {
+  try {
+    await sqlDataSource.query(
+      `
+      UPDATE 
+        users 
+      SET 
+        refresh_token= ?
+      WHERE id = ? `,
+      [refresh_token, userId]
+    );
+  } catch (err) {
+    console.log(err);
+    throw new Error("error: refresh token");
   }
 };
 
@@ -31,7 +49,7 @@ const getUserByEmail = async (email) => {
         WHERE
           users.email = ?
         `,
-    [ email ]
+    [email]
   );
   return user;
 };
@@ -50,10 +68,10 @@ const getUserById = async (id) => {
         WHERE 
           users.id = ?
         `,
-    [ id ]
+    [id]
   );
-  
+
   return user;
 };
 
-module.exports = { getUserByEmail, createUser,getUserById };
+module.exports = { getUserByEmail, createUser, getUserById, createRefreshToken };

--- a/src/services/likeService.js
+++ b/src/services/likeService.js
@@ -1,26 +1,27 @@
 const likeDao = require("../models/likeDao");
 
-const createLike = async(productId, userId) => {
-    const [checkLikeList] = await likeDao.checkLikeList(productId, userId)
+const createLike = async (productId, userId) => {
+  const [checkLikeList] = await likeDao.checkLikeList(productId, userId);
+  console.log(checkLikeList);
 
-    if (!productId) {
-        const err = new Error("INVALID_PRODUCT_ID");
-        err.statusCode = 400;
-        throw err;
-    }
-    
-    if (checkLikeList) {
-        await likeDao.deleteLike(productId, userId)
-        return false
-    } else {
-        await likeDao.createLike(productId, userId)
-        return true
-    }
-}
+  if (!productId) {
+    const err = new Error("INVALID_PRODUCT_ID");
+    err.statusCode = 400;
+    throw err;
+  }
+
+  if (checkLikeList) {
+    await likeDao.deleteLike(productId, userId);
+    return false;
+  } else {
+    await likeDao.createLike(productId, userId);
+    return true;
+  }
+};
 
 const getLikeList = async (userId) => {
-    const getLikeList = await likeDao.getLikeList(userId)
-    return getLikeList
-}
+  const getLikeList = await likeDao.getLikeList(userId);
+  return getLikeList;
+};
 
-module.exports = { createLike, getLikeList }
+module.exports = { createLike, getLikeList };

--- a/src/services/userService.js
+++ b/src/services/userService.js
@@ -2,6 +2,7 @@ const bcrypt = require("bcrypt");
 const jwt = require("jsonwebtoken");
 
 const { validateEmail } = require("../util/validators");
+const { generateAccessToken, generateRefreshToken } = require("../util/token");
 const userDao = require("../models/userDao");
 
 const signup = async (name, phone, email, password) => {
@@ -23,16 +24,16 @@ const signin = async (email, password) => {
     throw new Error("INVALID_USER", 401);
   }
 
-  const jwtToken = jwt.sign({ id: user.id }, process.env.JWT_SECRET_KEY, {
-    expiresIn: "1d",
-  });
+  const accessToken = generateAccessToken(user.id);
+  const refreshToken = generateRefreshToken(user.id);
+  await userDao.createRefreshToken(refreshToken, user.id);
 
-  return jwtToken;
+  return { accessToken, refreshToken };
 };
 
 const getUserById = async (id) => {
-  const user = await userDao.getUserById(id)
-  return user
-}
+  const user = await userDao.getUserById(id);
+  return user;
+};
 
 module.exports = { signup, signin, getUserById };

--- a/src/util/auth.js
+++ b/src/util/auth.js
@@ -1,23 +1,46 @@
-const jwt = require('jsonwebtoken');
-const  userService  = require('../services/userService');
-
+const jwt = require("jsonwebtoken");
+const userService = require("../services/userService");
+const { Errors } = require("./errors");
+const { generateAccessToken } = require("./token");
 
 const loginRequired = async (req, res, next) => {
   const accessToken = req.headers.authorization;
+  const refreshToken = req.headers.refresh_token;
+
   if (!accessToken) {
-    const error = new Error('NEED_ACCESSTOKEN');
-    error.statusCode = 401;
-    throw error;
+    throw new Errors("NEED_ACCESSTOKEN", 401);
   }
-  const verifyToken = jwt.verify(accessToken, process.env.JWT_SECRET_KEY);
-    const user = await userService.getUserById(verifyToken.id);
-  if (!user) {
-    const error = new Error('INVALID_USER');
-    error.statusCode = 400;
-    throw error;
+
+  try {
+    const decodedAccessToken = jwt.verify(accessToken, process.env.JWT_SECRET_KEY);
+    req.id = decodedAccessToken.id;
+    next();
+  } catch (err) {
+    //catch를 사용해 accessToken의 에러여부를 진단
+    // accessToken이 만료된 상황 -> refresh 토큰이 있는지 파악, 있으면 verify를 통해 access token 재발행,
+    if (err.name === "TokenExpiredError") {
+      try {
+        const decodedRefreshToken = jwt.verify(refreshToken, process.env.JWT_SECRET_KEY);
+        if (Date.now() >= decodedRefreshToken.exp * 1000) {
+          throw new Errors("RE_LOGIN_REQUIRED", 401);
+        }
+        const user = await userService.getUserById(decodedRefreshToken.id);
+        const newAccessToken = generateAccessToken(user.id);
+        req.id = user.id;
+        // 새로 발급된 access token은 response의 headers에 담아서 보낸다.
+        res.set("Authorization", newAccessToken);
+        next();
+      } catch (err) {
+        throw new Errors("JWT_REFRESH_ERROR", 401);
+      }
+    }
+    //access token의 signature의 인증이 실패한 상황
+    else if (err.message === "invalid signature") {
+      throw new Errors("CHECK_ACCESS_TOKEN_SECRET_KEY");
+    } else {
+      throw new Errors("JWT_ACCESS_ERROR");
+    }
   }
-  req.user = user;
-  next();
 };
 
 module.exports = { loginRequired };

--- a/src/util/token.js
+++ b/src/util/token.js
@@ -1,0 +1,17 @@
+const jwt = require("jsonwebtoken");
+
+const generateAccessToken = async (userId) => {
+  const accessToken = jwt.sign({ id: userId }, process.env.JWT_SECRET_KEY, {
+    expiresIn: process.env.JWT_ACCESS_TOKEN_EXPIRATION_TIME,
+  });
+  return accessToken;
+};
+
+const generateRefreshToken = async (userId) => {
+  const refreshToken = jwt.sign({ id: userId }, process.env.JWT_SECRET_KEY, {
+    expiresIn: process.env.JWT_REFRESH_TOKEN_EXPIRATION_TIME,
+  });
+  return refreshToken;
+};
+
+module.exports = { generateAccessToken, generateRefreshToken };


### PR DESCRIPTION
## :: 최근 작업 주제
- [X] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 
- 기본 JWT방식의 인증을 강화하기 위해 Refresh Token의 기능을 추가

<br />

## :: 구현 사항 설명 

- access token으로만 인증방식을 구현한다면 탈취 문제에 있어 유효시간을 짧게할 수 밖에 없고 그렇게되면 자주 로그인을 해줘야되는 문제를 해결하기 위해 refresh token의 기능을 추가하였다. 서버는 로그인 성공시 access token과 refresh token 모두를 발급하고 refresh token을 서버에 저장한다. refresh token은 보다 긴 유효기간을 가지고있어서 유효기간이 보다 짧은 access token이 만료되었을 때 재발급 해주는 열쇠의 역할은 한다. (JWT는 인증을 위해 사용되기에 payload에 중요한 정보를 담아서는 안된다!)

- access token을 검증할 때 만료가 되어 에러를 throw해주던 방식에서 try/catch를 사용해서 만료되어 에러가 나더라도 사용자에게 추가적인 요청이 아닌 내부적으로 해결할 수 있게 바꿨다. 사용자가 보다 쉽게 사이트에 접근할 수 있게끔 발생할 수 있는 hurdle을 제거해줄 수 있었다.
<br />

## :: 성장 포인트 
- try/catch문을 사용하여 사용자가 웹사이트를 이용할 때 hurdle이 되는 사항들을 제거해주며 사용자의 입장에서 개발을 하려고 생각하게되었다.

<br />

